### PR TITLE
update cmake minimal version to enable build on recent cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake setup for Unicorn 2.
 # By Huitao Chen & Nguyen Anh Quynh, 2019-2020
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.7.2)
 
 if(MSVC)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")


### PR DESCRIPTION
Hello @guillep !
Something I noticed while trying to install the libraries.

It was a small change, similar to what was needed for [#945. ](https://github.com/pharo-project/pharo-vm/pull/945) 


The following threw an error because of the minimal CMake version. 
"cmake .. -DCMAKE_BUILD_TYPE=Release"


